### PR TITLE
alternative `import` syntax (proposal)

### DIFF
--- a/src/plugins/lightscript.js
+++ b/src/plugins/lightscript.js
@@ -79,7 +79,7 @@ pp.parseForInIterationVariable = function (node, targetType = null) {
   }
 
   this.next();
-  node[iterType] = iterType === 'elem' || iterType === 'val'
+  node[iterType] = iterType === "elem" || iterType === "val"
     ? this.parseBindingAtom()
     : this.parseBindingIdentifier();
   return MATCHING_ITER_VARS[iterType];

--- a/test/fixtures/lightscript/import/complex/actual.js
+++ b/test/fixtures/lightscript/import/complex/actual.js
@@ -1,0 +1,1 @@
+import 'module': foo, { bar, baz as duck, qux as _ }

--- a/test/fixtures/lightscript/import/complex/expected.json
+++ b/test/fixtures/lightscript/import/complex/expected.json
@@ -1,0 +1,254 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 52,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 52
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 52,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 52
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 52
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportDefaultSpecifier",
+            "start": 17,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 20
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 17,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 24,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 29,
+            "end": 40,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 29
+              },
+              "end": {
+                "line": 1,
+                "column": 40
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 36,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 36
+                },
+                "end": {
+                  "line": 1,
+                  "column": 40
+                },
+                "identifierName": "duck"
+              },
+              "name": "duck"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 42,
+            "end": 50,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 42
+              },
+              "end": {
+                "line": 1,
+                "column": 50
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 42,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 42
+                },
+                "end": {
+                  "line": 1,
+                  "column": 45
+                },
+                "identifierName": "qux"
+              },
+              "name": "qux"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 49,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 49
+                },
+                "end": {
+                  "line": 1,
+                  "column": 50
+                },
+                "identifierName": "_"
+              },
+              "name": "_"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/default-and-named/actual.js
+++ b/test/fixtures/lightscript/import/default-and-named/actual.js
@@ -1,0 +1,1 @@
+import 'module': foo, { bar, baz }

--- a/test/fixtures/lightscript/import/default-and-named/expected.json
+++ b/test/fixtures/lightscript/import/default-and-named/expected.json
@@ -1,0 +1,204 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 34
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 34
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportDefaultSpecifier",
+            "start": 17,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 20
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 17,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 24,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 29,
+            "end": 32,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 29
+              },
+              "end": {
+                "line": 1,
+                "column": 32
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/default-as/actual.js
+++ b/test/fixtures/lightscript/import/default-as/actual.js
@@ -1,0 +1,1 @@
+import 'module': { default as foo }

--- a/test/fixtures/lightscript/import/default-as/expected.json
+++ b/test/fixtures/lightscript/import/default-as/expected.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 35,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 35
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 35,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 35
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 19,
+            "end": 33,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 33
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 19,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 26
+                },
+                "identifierName": "default"
+              },
+              "name": "default"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 30,
+              "end": 33,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 30
+                },
+                "end": {
+                  "line": 1,
+                  "column": 33
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/default/actual.js
+++ b/test/fixtures/lightscript/import/default/actual.js
@@ -1,0 +1,1 @@
+import 'module': foo

--- a/test/fixtures/lightscript/import/default/expected.json
+++ b/test/fixtures/lightscript/import/default/expected.json
@@ -1,0 +1,104 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 20,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 20,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 20,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 20
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportDefaultSpecifier",
+            "start": 17,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 20
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 17,
+              "end": 20,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 20
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/linebreak-after-brace/actual.js
+++ b/test/fixtures/lightscript/import/linebreak-after-brace/actual.js
@@ -1,0 +1,6 @@
+import 'module': {
+  foo,
+  bar,
+  baz,
+  qux
+}

--- a/test/fixtures/lightscript/import/linebreak-after-brace/expected.json
+++ b/test/fixtures/lightscript/import/linebreak-after-brace/expected.json
@@ -1,0 +1,272 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 47,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 47,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 47,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 21,
+            "end": 24,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 5
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 5
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 28,
+            "end": 31,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 2
+              },
+              "end": {
+                "line": 3,
+                "column": 5
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 28,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 5
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 28,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 5
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 35,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 2
+              },
+              "end": {
+                "line": 4,
+                "column": 5
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 35,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 5
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 35,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 5
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 42,
+            "end": 45,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 2
+              },
+              "end": {
+                "line": 5,
+                "column": 5
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 42,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5
+                },
+                "identifierName": "qux"
+              },
+              "name": "qux"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 42,
+              "end": 45,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5
+                },
+                "identifierName": "qux"
+              },
+              "name": "qux"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/linebreak-before-brace/actual.js
+++ b/test/fixtures/lightscript/import/linebreak-before-brace/actual.js
@@ -1,0 +1,2 @@
+import 'module':
+  { foo, bar, baz, qux }

--- a/test/fixtures/lightscript/import/linebreak-before-brace/expected.json
+++ b/test/fixtures/lightscript/import/linebreak-before-brace/expected.json
@@ -1,0 +1,272 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 24
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 24
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 21,
+            "end": 24,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 7
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 7
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 21,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 4
+                },
+                "end": {
+                  "line": 2,
+                  "column": 7
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 26,
+            "end": 29,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 26,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 12
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 26,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 12
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 31,
+            "end": 34,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 17
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 31,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 31,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 36,
+            "end": 39,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 19
+              },
+              "end": {
+                "line": 2,
+                "column": 22
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 36,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 19
+                },
+                "end": {
+                  "line": 2,
+                  "column": 22
+                },
+                "identifierName": "qux"
+              },
+              "name": "qux"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 36,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 19
+                },
+                "end": {
+                  "line": 2,
+                  "column": 22
+                },
+                "identifierName": "qux"
+              },
+              "name": "qux"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/named-as/actual.js
+++ b/test/fixtures/lightscript/import/named-as/actual.js
@@ -1,0 +1,1 @@
+import 'module': { foo as bar }

--- a/test/fixtures/lightscript/import/named-as/expected.json
+++ b/test/fixtures/lightscript/import/named-as/expected.json
@@ -1,0 +1,122 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 31,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 31
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 31,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 31
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 31,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 31
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 19,
+            "end": 29,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 29
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 19,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 26,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 26
+                },
+                "end": {
+                  "line": 1,
+                  "column": 29
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/named/actual.js
+++ b/test/fixtures/lightscript/import/named/actual.js
@@ -1,0 +1,1 @@
+import 'module': { foo, bar, baz }

--- a/test/fixtures/lightscript/import/named/expected.json
+++ b/test/fixtures/lightscript/import/named/expected.json
@@ -1,0 +1,222 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 34
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 34
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 19,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 19,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 19,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 24,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "bar"
+              },
+              "name": "bar"
+            }
+          },
+          {
+            "type": "ImportSpecifier",
+            "start": 29,
+            "end": 32,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 29
+              },
+              "end": {
+                "line": 1,
+                "column": 32
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 29,
+              "end": 32,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
+                },
+                "identifierName": "baz"
+              },
+              "name": "baz"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/namespace/actual.js
+++ b/test/fixtures/lightscript/import/namespace/actual.js
@@ -1,0 +1,1 @@
+import 'module': * as foo

--- a/test/fixtures/lightscript/import/namespace/expected.json
+++ b/test/fixtures/lightscript/import/namespace/expected.json
@@ -1,0 +1,104 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 25,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 25
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 25,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 25
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 25,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportNamespaceSpecifier",
+            "start": 17,
+            "end": 25,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 22,
+              "end": 25,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 22
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            }
+          }
+        ],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        },
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/no-binding/actual.js
+++ b/test/fixtures/lightscript/import/no-binding/actual.js
@@ -1,0 +1,1 @@
+import 'module'

--- a/test/fixtures/lightscript/import/no-binding/expected.json
+++ b/test/fixtures/lightscript/import/no-binding/expected.json
@@ -1,0 +1,70 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 15,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 15
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 15,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 15,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 15
+          }
+        },
+        "specifiers": [],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "module",
+            "raw": "'module'"
+          },
+          "value": "module"
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/import/options.json
+++ b/test/fixtures/lightscript/import/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["lightscript", "jsx", "flow"],
+  "sourceType": "module"
+}

--- a/test/fixtures/lightscript/import/source-quote-omission/actual.js
+++ b/test/fixtures/lightscript/import/source-quote-omission/actual.js
@@ -1,0 +1,1 @@
+import lodash: _

--- a/test/fixtures/lightscript/import/source-quote-omission/expected.json
+++ b/test/fixtures/lightscript/import/source-quote-omission/expected.json
@@ -1,0 +1,104 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 16,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 16
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 16,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 16,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 16
+          }
+        },
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            }
+          },
+          "extra": {
+            "rawValue": "lodash",
+            "raw": "lodash"
+          },
+          "value": "lodash"
+        },
+        "specifiers": [
+          {
+            "type": "ImportDefaultSpecifier",
+            "start": 15,
+            "end": 16,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 16
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 15,
+              "end": 16,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 15
+                },
+                "end": {
+                  "line": 1,
+                  "column": 16
+                },
+                "identifierName": "_"
+              },
+              "name": "_"
+            }
+          }
+        ],
+        "importKind": "value"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
JavaScript ES2015 introduced `import` as a standard syntax for bringing in modules. But the syntax is... unfortunately bound by its surroundings.

```js
// default export
import _ from 'lodash'
// named exports
import { map, reduce, filter } from 'lodash'
// all named exports
import * as util from './util'
// aliasing
import { get as getProp } from 'lodash'
```

While the above is readable in a strictly English-like sense, there are a few drawbacks to its syntax:

* not very predictable - the module source jumps all over the place
* module name coming second means it's difficult to offer meaningful suggestions

While there is and should be a strong case for keeping LightScript _familiar_ to JavaScript developers, that shouldn't necessarily mean we should always be absolutely constrained. This is especially true in cases where there's room for clear improvement - JavaScript is, for better or worse, bound by its environment and its commitment to backward compatibility. LightScript doesn't have this limitation yet.

This is a proposal to add an alternative syntax for `import` to LightScript.

## overview

This new syntax would take the form:

```js
import MODULE_NAME: IMPORT_SPECIFIERS
```

... where `IMPORT_SPECIFIERS` can take any form possible in vanilla
JavaScript.

## goals

* predictability

  The module name always remains in the same place - up front. The identifiers being imported from it always follow the `:`.

* familiarity

  Syntactically this is hardly different from JavaScript - the only real difference is that `from` is replaced by `:` and the source and the imported identifiers have switched positions, ie:

  ```js
  import id from 'module'
  ```

  ... is equivalent to:

  ```js
  import 'module': id
  ```

* developer ergonomics

  Since the module name comes first it would be possible to offer more useful intellisense / autocompletion on `import` statements. In the current state of things, if you start typing out an `import` from left to right you hit the specifiers first. This means you haven't said what you're importing _from_ yet, and so there's no real way for the environment to give you meaningful suggestions.

  It also requires less characters while remaining readable. The simple savings of `:` versus `from` is 3 characters per `import`... That'll add up fast.

## examples

### default export

Vanilla JavaScript: 

```js
import _ from 'lodash'
```

Alternative LightScript syntax:

```js
import 'lodash': _
```

### named exports

Vanilla JavaScript:

```js
import { map, reduce, filter } from 'lodash'
```

Alternative LightScript syntax:

```js
import 'lodash': { map, reduce, filter }
```

### namespace imports ( star / asterisk )

Vanilla JavaScript:

```js
import * as util from './util'
```

Alternative LightScript syntax:

```js
import './util': * as util
```

### aliased imports

Vanilla JavaScript:

```js
import { get as getProp } from 'lodash'
```

Alternative JavaScript syntax:

```js
import 'lodash': { get as getProp }
```

## annex

These are additional proposals that should be considered.

### quote omission

**This is rejected as it's not useful all that often - many npm modules contain hyphens, for example.**

When the source module's name is a valid JavaScript identifier, the quotes around it can be omitted:

```js
import lodash: _
import electron: { app, BrowserWindow }
import react: { Component }

// requires quotes
import 'is-plain-object': isPlainObject
```

This further reduces syntactic noise by dropping 2 potentially unnecessary characters.
